### PR TITLE
client:varlink_exec(): set DYLD_LIBRARY_PATH/LD_LIBRARY_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
 - cargo build --all
 - |
   export DYLD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$DYLD_LIBRARY_PATH
+  echo $DYLD_LIBRARY_PATH
   cargo test --all
 after_success: |
   if [[ $(uname) == *Linux* ]] && [[ "$TRAVIS_RUST_VERSION" == stable ]]; then

--- a/varlink/src/client.rs
+++ b/varlink/src/client.rs
@@ -25,7 +25,26 @@ pub enum VarlinkStream {
 pub fn varlink_exec<S: ?Sized + AsRef<str>>(
     address: &S,
 ) -> Result<(Child, String, Option<TempDir>)> {
-    let executable = String::from("exec ") + address.as_ref();
+    #[cfg(not(target_os = "macos"))]
+    mod sysenv {
+        pub const LOADER_PATH: &'static str = "LD_LIBRARY_PATH";
+    }
+    #[cfg(target_os = "macos")]
+    mod sysenv {
+        pub const LOADER_PATH: &'static str = "DYLD_LIBRARY_PATH";
+    }
+
+    let executable = match env::var(sysenv::LOADER_PATH) {
+        Ok(path) => format!(
+            "{}=\"${}:{}\" exec {}",
+            sysenv::LOADER_PATH,
+            sysenv::LOADER_PATH,
+            path,
+            address.as_ref()
+        ),
+        _ => String::from("exec ") + address.as_ref(),
+    };
+
     use unix_socket::UnixListener;
 
     let dir = tempdir()?;


### PR DESCRIPTION
otherwise we might get
    dyld: Library not loaded: @rpath/libproc_macro-f54717cad58ddd96.dylib
      Referenced from: /Users/travis/build/varlink/rust/target/debug/varlink-certification
      Reason: image not found