### PR TITLE
Use Rust stdlib Unix socket

### DIFF
--- a/varlink/Cargo.toml
+++ b/varlink/Cargo.toml
@@ -37,7 +37,6 @@ winapi = { version = "0.3", features = ["winuser", "winsock2"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0", default-features = false }
-unix_socket = "0.5"
 
 [dev-dependencies]
 static_assertions = "1.1.0"

--- a/varlink/src/server.rs
+++ b/varlink/src/server.rs
@@ -71,13 +71,9 @@ fn activation_listener() -> Result<Option<usize>> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_abstract_unixlistener(addr: &str) -> Result<UnixListener> {
-    // FIXME: abstract unix domains sockets still not in std
-    // FIXME: https://github.com/rust-lang/rust/issues/14194
-    use unix_socket::UnixListener as AbstractUnixListener;
-
     unsafe {
         Ok(UnixListener::from_raw_fd(
-            AbstractUnixListener::bind(addr)
+            UnixListener::bind(addr)
                 .map_err(map_context!())?
                 .into_raw_fd(),
         ))


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/14194 has been resolved, [`unix_socket`](https://github.com/rust-lang-nursery/unix-socket) is deprecated.