### PR TITLE
"proc_macro" -> "proc-macro"

### DIFF
--- a/varlink_derive/Cargo.toml
+++ b/varlink_derive/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/varlink/rust"
 description = "Rust code generator macro for the varlink protocol."
 
 [lib]
-proc_macro = true
+proc-macro = true
 name = "varlink_derive"
 path = "src/lib.rs"
 


### PR DESCRIPTION
"proc-macro" is the documented way of marking a package as a Procedural Macro package: https://doc.rust-lang.org/reference/procedural-macros.html.

Relates to #30. Note that "proc_macro" is also supported by cargo.

My motivation for this PR is that I want to use `varlink_derive` from a project that uses Carnix, which strictly follows the documentation by supporting _only_ "proc-macro", but not "proc_macro". I fully acknowledge that it may be a little odd to change the manifest to adhere to the overly strict options interpretation of some build tool.

However,
- "proc-macro" is _the_ documented way of making a Procedural Macro package
- This change will only increase this crate's compatibility with build systems, so there will be zero effect on almost all users, and a select few will rejoice because they can now use it whereas previously they couldn't