### PR TITLE
Update Cargo.toml

### DIFF
--- a/varlink-cli/Cargo.toml
+++ b/varlink-cli/Cargo.toml
@@ -23,5 +23,5 @@ serde_json = "1.0.41"
 clap = "2.33.0"
 colored_json = "2.1.0"
 chainerror = "0.7.0"
-libc = { version = "0", default-features = false }
+libc = { version = "0.2.126", default-features = false }
 bitflags = "1.2.1"

--- a/varlink/Cargo.toml
+++ b/varlink/Cargo.toml
@@ -36,7 +36,7 @@ uds_windows = { version="1.0.1" }
 winapi = { version = "0.3", features = ["winuser", "winsock2"] }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0", default-features = false }
+libc = { version = "0.2.126", default-features = false }
 unix_socket = "0.5"
 
 [dev-dependencies]


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.

Also libc doesnt follow semver so it is better to mention the full version