### PR TITLE
Migrate varlink_generator to syn 2.0.x

### DIFF
--- a/examples/more/src/org_example_more.rs
+++ b/examples/more/src/org_example_more.rs
@@ -120,6 +120,7 @@ impl From<&varlink::Reply> for ErrorKind {
         }
     }
 }
+#[allow(dead_code)]
 pub trait VarlinkCallError: varlink::CallTrait {
     fn reply_test_more_error(&mut self, r#reason: String) -> varlink::Result<()> {
         self.reply_struct(varlink::Reply::error(
@@ -151,6 +152,7 @@ impl varlink::VarlinkReply for Ping_Reply {}
 pub struct Ping_Args {
     pub r#ping: String,
 }
+#[allow(dead_code)]
 pub trait Call_Ping: VarlinkCallError {
     fn reply(&mut self, r#pong: String) -> varlink::Result<()> {
         self.reply_struct(Ping_Reply { r#pong }.into())
@@ -162,6 +164,7 @@ pub struct StopServing_Reply {}
 impl varlink::VarlinkReply for StopServing_Reply {}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct StopServing_Args {}
+#[allow(dead_code)]
 pub trait Call_StopServing: VarlinkCallError {
     fn reply(&mut self) -> varlink::Result<()> {
         self.reply_struct(varlink::Reply::parameters(None))
@@ -177,12 +180,14 @@ impl varlink::VarlinkReply for TestMore_Reply {}
 pub struct TestMore_Args {
     pub r#n: i64,
 }
+#[allow(dead_code)]
 pub trait Call_TestMore: VarlinkCallError {
     fn reply(&mut self, r#state: State) -> varlink::Result<()> {
         self.reply_struct(TestMore_Reply { r#state }.into())
     }
 }
 impl<'a> Call_TestMore for varlink::Call<'a> {}
+#[allow(dead_code)]
 pub trait VarlinkInterface {
     fn ping(&self, call: &mut dyn Call_Ping, r#ping: String) -> varlink::Result<()>;
     fn stop_serving(&self, call: &mut dyn Call_StopServing) -> varlink::Result<()>;
@@ -195,6 +200,7 @@ pub trait VarlinkInterface {
         Ok(Vec::new())
     }
 }
+#[allow(dead_code)]
 pub trait VarlinkClientInterface {
     fn ping(&mut self, r#ping: String) -> varlink::MethodCall<Ping_Args, Ping_Reply, Error>;
     fn stop_serving(&mut self) -> varlink::MethodCall<StopServing_Args, StopServing_Reply, Error>;

--- a/examples/ping/src/org_example_ping.rs
+++ b/examples/ping/src/org_example_ping.rs
@@ -120,6 +120,7 @@ impl From<&varlink::Reply> for ErrorKind {
         }
     }
 }
+#[allow(dead_code)]
 pub trait VarlinkCallError: varlink::CallTrait {
     fn reply_ping_error(&mut self, r#parameter: i64) -> varlink::Result<()> {
         self.reply_struct(varlink::Reply::error(
@@ -145,6 +146,7 @@ impl varlink::VarlinkReply for Ping_Reply {}
 pub struct Ping_Args {
     pub r#ping: String,
 }
+#[allow(dead_code)]
 pub trait Call_Ping: VarlinkCallError {
     fn reply(&mut self, r#pong: String) -> varlink::Result<()> {
         self.reply_struct(Ping_Reply { r#pong }.into())
@@ -156,12 +158,14 @@ pub struct Upgrade_Reply {}
 impl varlink::VarlinkReply for Upgrade_Reply {}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Upgrade_Args {}
+#[allow(dead_code)]
 pub trait Call_Upgrade: VarlinkCallError {
     fn reply(&mut self) -> varlink::Result<()> {
         self.reply_struct(varlink::Reply::parameters(None))
     }
 }
 impl<'a> Call_Upgrade for varlink::Call<'a> {}
+#[allow(dead_code)]
 pub trait VarlinkInterface {
     fn ping(&self, call: &mut dyn Call_Ping, r#ping: String) -> varlink::Result<()>;
     fn upgrade(&self, call: &mut dyn Call_Upgrade) -> varlink::Result<()>;
@@ -173,6 +177,7 @@ pub trait VarlinkInterface {
         Ok(Vec::new())
     }
 }
+#[allow(dead_code)]
 pub trait VarlinkClientInterface {
     fn ping(&mut self, r#ping: String) -> varlink::MethodCall<Ping_Args, Ping_Reply, Error>;
     fn upgrade(&mut self) -> varlink::MethodCall<Upgrade_Args, Upgrade_Reply, Error>;

--- a/varlink-cli/src/proxy.rs
+++ b/varlink-cli/src/proxy.rs
@@ -85,7 +85,7 @@ where
                         }
                     };
                 }
-                last_iface = iface.clone();
+                last_iface.clone_from(&iface);
             }
 
             let mut stream = match varlink_connect(&address) {
@@ -220,10 +220,10 @@ where
     Ok(upgraded)
 }
 
-pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<u64>
+pub fn copy<R, W>(reader: &mut R, writer: &mut W) -> io::Result<u64>
 where
-    R: Read,
-    W: Write,
+    R: Read + ?Sized,
+    W: Write + ?Sized,
 {
     use std::io::ErrorKind;
 

--- a/varlink-cli/src/watchclose_epoll.rs
+++ b/varlink-cli/src/watchclose_epoll.rs
@@ -98,9 +98,9 @@ fn cvt<T: IsMinusOne>(t: T) -> crate::io::Result<T> {
 
 fn max_len() -> usize {
     if cfg!(target_os = "macos") {
-        <c_int>::max_value() as usize - 1
+        <c_int>::MAX as usize - 1
     } else {
-        <ssize_t>::max_value() as usize
+        <ssize_t>::MAX as usize
     }
 }
 

--- a/varlink/src/test.rs
+++ b/varlink/src/test.rs
@@ -38,7 +38,7 @@ fn test_listen() -> Result<()> {
             assert_eq!(&info.version, "0.1");
             assert_eq!(&info.url, "http://varlink.org");
             assert_eq!(
-                info.interfaces.get(0).unwrap().as_ref(),
+                info.interfaces.first().unwrap().as_ref(),
                 "org.varlink.service"
             );
         }
@@ -161,13 +161,14 @@ fn test_handle() -> Result<()> {
 
     let mut buf = Vec::<u8>::new();
 
-    for mut i in vec![a, b, c] {
+    for mut i in [a, b, c] {
         buf.append(&mut i);
 
-        match {
+        let res = {
             let mut br = buf.as_slice();
             service.handle(&mut br, &mut w, None)?
-        } {
+        };
+        match res {
             (_, Some(iface)) => {
                 panic!("Unexpected handle return value {}", iface);
             }

--- a/varlink_generator/Cargo.toml
+++ b/varlink_generator/Cargo.toml
@@ -28,7 +28,7 @@ varlink_parser = { version = "4.3", path = "../varlink_parser" }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 getopts = "0.2.21"
-syn = "1.0.8"
+syn = "2.0"
 chainerror = "0.8.0"
 
 [dev-dependencies]

--- a/varlink_generator/src/lib.rs
+++ b/varlink_generator/src/lib.rs
@@ -378,6 +378,7 @@ fn varlink_to_rust(idl: &IDL, options: &GeneratorOptions, tosource: bool) -> Res
             let field_types_1 = out_field_types.iter();
             if !t.output.elts.is_empty() {
                 ts.extend(quote!(
+                #[allow(dead_code)]
                 pub trait #call_name: VarlinkCallError {
                     fn reply(&mut self, #(#field_names_1: #field_types_1),*) -> varlink::Result<()> {
                         self.reply_struct(#out_struct_name { #(#field_names_2),* }.into())
@@ -386,6 +387,7 @@ fn varlink_to_rust(idl: &IDL, options: &GeneratorOptions, tosource: bool) -> Res
             ));
             } else {
                 ts.extend(quote!(
+                    #[allow(dead_code)]
                     pub trait #call_name: VarlinkCallError {
                         fn reply(&mut self) -> varlink::Result<()> {
                             self.reply_struct(varlink::Reply::parameters(None))
@@ -467,6 +469,7 @@ fn varlink_to_rust(idl: &IDL, options: &GeneratorOptions, tosource: bool) -> Res
     }
 
     ts.extend(quote!(
+        #[allow(dead_code)]
         pub trait VarlinkInterface {
             #server_method_decls
 
@@ -474,6 +477,8 @@ fn varlink_to_rust(idl: &IDL, options: &GeneratorOptions, tosource: bool) -> Res
                 Ok(Vec::new())
             }
         }
+
+        #[allow(dead_code)]
         pub trait VarlinkClientInterface {
             #client_method_decls
         }
@@ -776,6 +781,7 @@ fn generate_error_code(
         }
         ts.extend(quote!(
             #error_structs_and_enums
+            #[allow(dead_code)]
             pub trait VarlinkCallError: varlink::CallTrait {
                 #funcs
             }
@@ -880,7 +886,7 @@ pub fn cargo_build<T: AsRef<Path> + ?Sized>(input_path: &T) {
 /// }
 /// ```
 ///
-pub fn cargo_build_many<T: AsRef<Path> + ?Sized>(input_paths: &[T])
+pub fn cargo_build_many<T>(input_paths: &[T])
 where
     T: std::marker::Sized,
     T: AsRef<Path>,

--- a/varlink_generator/tests/org.example.complex.rs_out
+++ b/varlink_generator/tests/org.example.complex.rs_out
@@ -147,6 +147,7 @@ pub enum r#ErrorFoo_Args_bar {
     r#if,
     r#let,
 }
+#[allow(dead_code)]
 pub trait VarlinkCallError: varlink::CallTrait {
     fn reply_error_bar(&mut self) -> varlink::Result<()> {
         self.reply_struct(varlink::Reply::error("org.example.complex.ErrorBar", None))
@@ -256,6 +257,7 @@ pub struct Bar_Reply {}
 impl varlink::VarlinkReply for Bar_Reply {}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Bar_Args {}
+#[allow(dead_code)]
 pub trait Call_Bar: VarlinkCallError {
     fn reply(&mut self) -> varlink::Result<()> {
         self.reply_struct(varlink::Reply::parameters(None))
@@ -285,6 +287,7 @@ pub struct Foo_Args {
     pub r#foo: TypeFoo,
     pub r#interface: Interface,
 }
+#[allow(dead_code)]
 pub trait Call_Foo: VarlinkCallError {
     fn reply(
         &mut self,
@@ -303,6 +306,7 @@ pub trait Call_Foo: VarlinkCallError {
     }
 }
 impl<'a> Call_Foo for varlink::Call<'a> {}
+#[allow(dead_code)]
 pub trait VarlinkInterface {
     fn bar(&self, call: &mut dyn Call_Bar) -> varlink::Result<()>;
     fn foo(
@@ -320,6 +324,7 @@ pub trait VarlinkInterface {
         Ok(Vec::new())
     }
 }
+#[allow(dead_code)]
 pub trait VarlinkClientInterface {
     fn bar(&mut self) -> varlink::MethodCall<Bar_Args, Bar_Reply, Error>;
     fn foo(

--- a/varlink_parser/src/format.rs
+++ b/varlink_parser/src/format.rs
@@ -625,7 +625,6 @@ impl<'a> FormatColored for IDL<'a> {
             if !t.doc.is_empty() {
                 f += &t
                     .doc
-                    .to_string()
                     .split('\n')
                     .map(|s| format!("{:indent$}{}", "", s.blue(), indent = indent))
                     .collect::<Vec<String>>()
@@ -661,7 +660,6 @@ impl<'a> FormatColored for IDL<'a> {
             if !m.doc.is_empty() {
                 f += &m
                     .doc
-                    .to_string()
                     .split('\n')
                     .map(|s| format!("{:indent$}{}", "", s.blue(), indent = indent))
                     .collect::<Vec<String>>()
@@ -726,7 +724,6 @@ impl<'a> FormatColored for IDL<'a> {
             if !t.doc.is_empty() {
                 f += &t
                     .doc
-                    .to_string()
                     .split('\n')
                     .map(|s| format!("{:indent$}{}", "", s.blue(), indent = indent))
                     .collect::<Vec<String>>()


### PR DESCRIPTION
Since the varlink_generator doesn't make use of anything that broke after syn was updated to 2.0.x, all it took was changing the version in the Cargo.toml file.