### PR TITLE
Do not invoke accept() on an already-established connection

### DIFF
--- a/varlink/src/server.rs
+++ b/varlink/src/server.rs
@@ -151,6 +151,13 @@ impl Listener {
         }
     }
 
+    pub const fn is_already_accepted(&self) -> bool {
+        match *self {
+            Self::TCP(_, value) => value,
+            Self::UNIX(_, value) => value,
+        }
+    }
+
     #[cfg(windows)]
     pub fn accept(&self, timeout: u64) -> Result<Box<dyn Stream>> {
         use winapi::um::winsock2::WSAEINTR as EINTR;
@@ -194,13 +201,21 @@ impl Listener {
         }
 
         match self {
-            &Listener::TCP(Some(ref l), _) => {
-                let (s, _addr) = l.accept().map_err(map_context!())?;
-                Ok(Box::new(s))
+            &Listener::TCP(Some(ref l), accepted) => {
+                if accepted {
+                    unsafe { Ok(Box::new(TcpStream::from_raw_fd(l.as_raw_fd()))) }
+                } else {
+                    let (s, _addr) = l.accept().map_err(map_context!())?;
+                    Ok(Box::new(s))
+                }
             }
-            Listener::UNIX(Some(ref l), _) => {
-                let (s, _addr) = l.accept().map_err(map_context!())?;
-                Ok(Box::new(s))
+            Listener::UNIX(Some(ref l), accepted) => {
+                if *accepted {
+                    unsafe { Ok(Box::new(UnixStream::from_raw_fd(l.as_raw_fd()))) }
+                } else {
+                    let (s, _addr) = l.accept().map_err(map_context!())?;
+                    Ok(Box::new(s))
+                }
             }
             _ => Err(context!(ErrorKind::ConnectionClosed)),
         }
@@ -250,13 +265,21 @@ impl Listener {
             }
         }
         match self {
-            &Listener::TCP(Some(ref l), _) => {
-                let (s, _addr) = l.accept().map_err(map_context!())?;
-                Ok(Box::new(s))
+            &Listener::TCP(Some(ref l), accepted) => {
+                if accepted {
+                    unsafe { Ok(Box::new(TcpStream::from_raw_fd(l.as_raw_fd()))) }
+                } else {
+                    let (s, _addr) = l.accept().map_err(map_context!())?;
+                    Ok(Box::new(s))
+                }
             }
-            Listener::UNIX(Some(ref l), _) => {
-                let (s, _addr) = l.accept().map_err(map_context!())?;
-                Ok(Box::new(s))
+            Listener::UNIX(Some(ref l), accepted) => {
+                if *accepted {
+                    unsafe { Ok(Box::new(UnixStream::from_raw_fd(l.as_raw_fd()))) }
+                } else {
+                    let (s, _addr) = l.accept().map_err(map_context!())?;
+                    Ok(Box::new(s))
+                }
             }
             _ => Err(context!(ErrorKind::ConnectionClosed)),
         }
@@ -607,5 +630,9 @@ pub fn listen<S: ?Sized + AsRef<str>, H: crate::ConnectionHandler + Send + Sync 
                 }
             }
         });
+
+        if listener.is_already_accepted() {
+            return Ok(());
+        }
     }
 }


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing and maintaining the Rust reference implementation of varlink!

Here's a proposed fix for #73; the `Listener::new()` method already records the fact that this listener is actually a connection that has already been established via socket activation, and lets the `Listener::accept()` method honor that flag.

I have written a trivial `varlink` server - [my varlink-hello GitLab project](https://gitlab.com/ppentchev/varlink-hello) - to demonstrate the need for this change. Without it, with the stock `varlink 11.0.1` crate, the `varlink-hello` program fails, since `Listener::accept()` attempts to invoke the `accept()` method of the "Unix listener" which is actually an already-connected socket.

Now, there are two things I don't completely like about this patch:
- I'm not overly fond of the use of `unsafe { ... }` in `Listener::accept()`. A cleaner way to do that would be to add two new values to the `Listener` enum, e.g. `TCPAccepted` and `UNIXAccepted`, and make `Listener::new()` create a `TcpListener` or a `UnixListener` directly, in its own `unsafe { ... }` blocks. This might cause a bit of code churn; let me know if I should do it.
- I currently have no way of testing the Windows implementation; I'd be very grateful if somebody could try to build the `varlink-hello` program under Windows and see if a) it fails with the currently-released `varlink` crate, and b) this change fixes it.

Thanks in advance for your time, and keep up the great work!

G'luck,
Peter