### PR TITLE
examples: Use anyhow

### DIFF
--- a/examples/example/Cargo.toml
+++ b/examples/example/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 rust-version = "1.70.0"
 
 [dependencies]
+anyhow = "1"
 varlink = { path = "../../varlink" }
 serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
 getopts = "0.2.21"
 varlink_derive = { path = "../../varlink_derive" }
-chainerror = "0.8.0"

--- a/examples/example/src/main.rs
+++ b/examples/example/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::process::exit;
 use std::sync::{Arc, RwLock};
 
-use chainerror::prelude::v1::*;
+use anyhow::Context;
 use varlink::{Connection, OrgVarlinkServiceInterface, VarlinkService};
 
 use crate::org_example_network::VarlinkClientInterface;

--- a/examples/ping/Cargo.toml
+++ b/examples/ping/Cargo.toml
@@ -8,13 +8,13 @@ publish = false
 rust-version = "1.70.0"
 
 [dependencies]
+anyhow = "1"
 varlink = { version = "11", path = "../../varlink" }
 serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
 getopts = "0.2.21"
 libc = "0.2.65"
-chainerror = "0.8.0"
 
 [build-dependencies]
 varlink_generator = { path = "../../varlink_generator" }

--- a/examples/ping/src/main.rs
+++ b/examples/ping/src/main.rs
@@ -1,9 +1,9 @@
-use chainerror::prelude::v1::*;
 use std::env;
 use std::io::{BufRead, Read, Write};
 use std::process::exit;
 use std::sync::{Arc, RwLock};
 
+use anyhow::Context;
 use varlink::{Call, Connection, VarlinkService};
 
 use crate::org_example_ping::*;

--- a/examples/ping/src/test.rs
+++ b/examples/ping/src/test.rs
@@ -3,7 +3,7 @@ use std::result::Result as StdResult;
 
 type Result<T> = StdResult<T, Box<dyn StdError>>;
 
-use chainerror::prelude::v1::*;
+use anyhow::Context;
 use std::io::BufRead;
 use std::{thread, time};
 use varlink::Connection;


### PR DESCRIPTION
This is a very widely used error crate suitable for apps and examples exactly like these, in contrast to `chainerror`
which is only used by this project. Prep for reworking our error handling more generally.