### PR TITLE
Update to chainerror 1.0

### DIFF
--- a/varlink-certification/Cargo.toml
+++ b/varlink-certification/Cargo.toml
@@ -13,7 +13,7 @@ serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
 getopts = "0.2.21"
-chainerror = "0.8.0"
+chainerror = "1"
 
 [build-dependencies]
 varlink_generator = { path = "../varlink_generator" }

--- a/varlink-certification/src/main.rs
+++ b/varlink-certification/src/main.rs
@@ -6,10 +6,9 @@ use std::process::exit;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
-use chainerror::prelude::v1::*;
-
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+use chainerror::Context;
 use varlink::{Connection, StringHashMap, StringHashSet, VarlinkService};
 
 mod org_varlink_certification {
@@ -685,13 +684,13 @@ impl org_varlink_certification::VarlinkInterface for CertInterface {
     }
 }
 
-struct Context {
+struct TestContext {
     test: String,
 }
 
 struct ClientIds {
     lifetimes: VecDeque<(Instant, String)>,
-    contexts: StringHashMap<Context>,
+    contexts: StringHashMap<TestContext>,
     max_lifetime: u64,
 }
 
@@ -741,7 +740,7 @@ impl ClientIds {
         let client_id = format!("{:x}", hasher.finish());
         self.contexts.insert(
             client_id.clone(),
-            Context {
+            TestContext {
                 test: "Test01".into(),
             },
         );

--- a/varlink_generator/Cargo.toml
+++ b/varlink_generator/Cargo.toml
@@ -29,7 +29,7 @@ quote = "1.0.2"
 proc-macro2 = "1.0.6"
 getopts = "0.2.21"
 syn = "2.0"
-chainerror = "0.8.0"
+chainerror = "1"
 
 [dev-dependencies]
 unified-diff = "0.2.1"

--- a/varlink_generator/src/bin/varlink-rust-generator.rs
+++ b/varlink_generator/src/bin/varlink-rust-generator.rs
@@ -19,7 +19,7 @@ use std::io;
 use std::io::{Read, Write};
 use std::path::Path;
 
-use chainerror::prelude::v1::*;
+use chainerror::Context;
 use varlink_generator::generate;
 
 fn print_usage(program: &str, opts: &getopts::Options) {

--- a/varlink_generator/src/lib.rs
+++ b/varlink_generator/src/lib.rs
@@ -40,14 +40,14 @@ use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
 use std::str::FromStr;
 
-use chainerror::prelude::v1::*;
+use chainerror::Context;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 
 use varlink_parser::{Typedef, VEnum, VError, VStruct, VStructOrEnum, VType, VTypeExt, IDL};
 
-derive_str_context!(Error);
-pub type Result<T> = ChainResult<T, Error>;
+chainerror::str_context!(Error);
+pub type Result<T> = chainerror::Result<T, Error>;
 
 trait ToRustString<'short, 'long: 'short> {
     fn to_rust_string(

--- a/varlink_parser/Cargo.toml
+++ b/varlink_parser/Cargo.toml
@@ -20,5 +20,5 @@ travis-ci = { repository = "varlink/rust" }
 
 [dependencies]
 colored = "2.1.0"
-chainerror = "0.8.0"
+chainerror = "1"
 peg = "0.6.3"

--- a/varlink_parser/src/lib.rs
+++ b/varlink_parser/src/lib.rs
@@ -44,11 +44,11 @@
     html_favicon_url = "https://varlink.org/images/varlink-small.png"
 )]
 
+use chainerror::Context;
+
 use self::varlink_grammar::ParseInterface;
 use std::collections::BTreeMap;
 use std::collections::HashSet;
-
-use chainerror::prelude::v1::*;
 
 mod format;
 
@@ -60,7 +60,7 @@ mod test;
 
 mod varlink_grammar;
 
-derive_str_context!(Error);
+chainerror::str_context!(Error);
 
 pub enum VType<'a> {
     Bool,
@@ -219,13 +219,13 @@ impl<'a> IDL<'a> {
     }
 
     #[deprecated(since = "4.1.0", note = "please use `IDL::try_from` instead")]
-    pub fn from_string(s: &'a str) -> ChainResult<Self, Error> {
+    pub fn from_string(s: &'a str) -> chainerror::Result<Self, Error> {
         IDL::try_from(s)
     }
 }
 
 impl<'a> TryFrom<&'a str> for IDL<'a> {
-    type Error = ChainError<Error>;
+    type Error = chainerror::Error<Error>;
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
         let interface = ParseInterface(value).map_context(|e| {


### PR DESCRIPTION
I think eventually we want to use e.g. `thiserror` or `anyhow` (more widely used crates) but for now let's just update to the latest of this one.