### PR TITLE
all: Port from `chainerror` to `thiserror`

### DIFF
--- a/varlink-certification/Cargo.toml
+++ b/varlink-certification/Cargo.toml
@@ -13,7 +13,7 @@ serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
 getopts = "0.2.21"
-chainerror = "1"
+thiserror = "2.0.3"
 
 [build-dependencies]
 varlink_generator = { path = "../varlink_generator" }

--- a/varlink-certification/src/main.rs
+++ b/varlink-certification/src/main.rs
@@ -8,7 +8,6 @@ use std::time::Instant;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-use chainerror::Context;
 use varlink::{Connection, StringHashMap, StringHashSet, VarlinkService};
 
 mod org_varlink_certification {
@@ -72,7 +71,7 @@ fn main() -> Result<()> {
         let connection = match matches.opt_str("varlink") {
             None => match matches.opt_str("bridge") {
                 Some(bridge) => Connection::with_bridge(&bridge)
-                    .context(format!("Connection::with_bridge({})", bridge))?,
+                    .map_err(|e| format!("Connection::with_bridge({bridge}): {e}"))?,
                 None => Connection::with_activate(&format!(
                     "{} \
                      --varlink=$VARLINK_ADDRESS",
@@ -80,7 +79,7 @@ fn main() -> Result<()> {
                 ))?,
             },
             Some(address) => Connection::with_address(&address)
-                .context(format!("Connection::with_address({})", address))?,
+                .map_err(|e| format!("Connection::with_address({address}): {e}"))?,
         };
         run_client(connection)?
     } else if let Some(address) = matches.opt_str("varlink") {

--- a/varlink-cli/Cargo.toml
+++ b/varlink-cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 varlink = { version = "11", path = "../varlink" }
 varlink_stdinterfaces = { version = "11", path = "../varlink_stdinterfaces" }
-varlink_parser = { version = "4.3", path = "../varlink_parser" }
+varlink_parser = { version = "5.0", path = "../varlink_parser" }
 serde = "1.0.102"
 serde_json = "1.0.41"
 clap = "2.33.0"

--- a/varlink-cli/Cargo.toml
+++ b/varlink-cli/Cargo.toml
@@ -23,6 +23,6 @@ serde = "1.0.102"
 serde_json = "1.0.41"
 clap = "2.33.0"
 colored_json = "2.1.0"
-chainerror = "0.8.0"
+anyhow = "1.0.93"
 libc = { version = "0.2.126", default-features = false }
 bitflags = "1.2.1"

--- a/varlink_derive/Cargo.toml
+++ b/varlink_derive/Cargo.toml
@@ -16,5 +16,4 @@ name = "varlink_derive"
 path = "src/lib.rs"
 
 [dependencies]
-varlink_generator = { version = "10.1", path = "../varlink_generator" }
-
+varlink_generator = { version = "11.0", path = "../varlink_generator" }

--- a/varlink_derive/src/lib.rs
+++ b/varlink_derive/src/lib.rs
@@ -151,17 +151,7 @@ fn parse_varlink_args(input: TokenStream) -> (String, String, Span) {
 }
 
 fn expand_varlink(name: String, source: String) -> TokenStream {
-    let code = match varlink_generator::compile(source) {
-        Ok(code) => code,
-        Err(e) => {
-            let mut s = String::new();
-            for i in e.iter() {
-                s += &i.to_string();
-                s += "\n";
-            }
-            panic!("{}", s)
-        }
-    };
+    let code = varlink_generator::compile(source).unwrap();
 
     format!("mod {} {{ {} }}", name, code).parse().unwrap()
 }

--- a/varlink_generator/Cargo.toml
+++ b/varlink_generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "varlink_generator"
-version = "10.1.1"
+version = "11.0.0"
 authors = ["Harald Hoyer <harald@hoyer.xyz>"]
 edition = "2018"
 rust-version = "1.70.0"
@@ -24,7 +24,7 @@ name = "varlink-rust-generator"
 path = "src/bin/varlink-rust-generator.rs"
 
 [dependencies]
-varlink_parser = { version = "4.3", path = "../varlink_parser" }
+varlink_parser = { version = "5.0", path = "../varlink_parser" }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 getopts = "0.2.21"

--- a/varlink_generator/Cargo.toml
+++ b/varlink_generator/Cargo.toml
@@ -29,7 +29,7 @@ quote = "1.0.2"
 proc-macro2 = "1.0.6"
 getopts = "0.2.21"
 syn = "2.0"
-chainerror = "1"
+thiserror = "2.0.3"
 
 [dev-dependencies]
 unified-diff = "0.2.1"

--- a/varlink_generator/src/bin/varlink-rust-generator.rs
+++ b/varlink_generator/src/bin/varlink-rust-generator.rs
@@ -19,7 +19,6 @@ use std::io;
 use std::io::{Read, Write};
 use std::path::Path;
 
-use chainerror::Context;
 use varlink_generator::generate;
 
 fn print_usage(program: &str, opts: &getopts::Options) {
@@ -59,7 +58,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             } else {
                 Box::new(
                     File::open(Path::new(&matches.free[0]))
-                        .context(format!("Failed to open '{}'", &matches.free[0]))?,
+                        .map_err(|e| format!("Failed to open '{}': {e}", &matches.free[0]))?,
                 )
             }
         }

--- a/varlink_parser/Cargo.toml
+++ b/varlink_parser/Cargo.toml
@@ -20,5 +20,5 @@ travis-ci = { repository = "varlink/rust" }
 
 [dependencies]
 colored = "2.1.0"
-chainerror = "1"
+thiserror = "2.0.3"
 peg = "0.6.3"

--- a/varlink_parser/Cargo.toml
+++ b/varlink_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "varlink_parser"
-version = "4.3.0"
+version = "5.0.0"
 authors = ["Harald Hoyer <harald@hoyer.xyz>"]
 edition = "2018"
 rust-version = "1.70.0"

--- a/varlink_parser/src/test.rs
+++ b/varlink_parser/src/test.rs
@@ -330,10 +330,10 @@ method F() -> ()
     .unwrap();
     assert_eq!(
         e.to_string(),
-        "Interface definition error: '\
+        "Interface definition error: \
 Interface `foo.example`: multiple definitions of method `F`!
 Interface `foo.example`: multiple definitions of type `Device`!
-Interface `foo.example`: multiple definitions of type `T`!'
+Interface `foo.example`: multiple definitions of type `T`!
 "
     );
 }

--- a/varlink_stdinterfaces/Cargo.toml
+++ b/varlink_stdinterfaces/Cargo.toml
@@ -19,7 +19,7 @@ serde_derive = "1.0.102"
 serde_json = "1.0.41"
 
 [build-dependencies]
-varlink_generator = { version = "10", path = "../varlink_generator" }
+varlink_generator = { version = "11", path = "../varlink_generator" }
 
 [dev-dependencies]
 static_assertions = "1.1.0"


### PR DESCRIPTION
The latter is quite ubiquitous in the Rust ecosystem so let's use that.

Warning: This is a breaking change so the semver versions are also being bumped.