### PR TITLE
varlink_generator: Fix generating code which compiles with Rust 2024

### DIFF
--- a/examples/more/src/org_example_more.rs
+++ b/examples/more/src/org_example_more.rs
@@ -104,18 +104,18 @@ impl From<&varlink::Reply> for ErrorKind {
     #[allow(unused_variables)]
     fn from(e: &varlink::Reply) -> Self {
         match e {
-            varlink::Reply {
-                error: Some(ref t), ..
-            } if t == "org.example.more.TestMoreError" => match e {
-                varlink::Reply {
-                    parameters: Some(p),
-                    ..
-                } => match serde_json::from_value(p.clone()) {
-                    Ok(v) => ErrorKind::TestMoreError(v),
-                    Err(_) => ErrorKind::TestMoreError(None),
-                },
-                _ => ErrorKind::TestMoreError(None),
-            },
+            varlink::Reply { error: Some(t), .. } if t == "org.example.more.TestMoreError" => {
+                match e {
+                    varlink::Reply {
+                        parameters: Some(p),
+                        ..
+                    } => match serde_json::from_value(p.clone()) {
+                        Ok(v) => ErrorKind::TestMoreError(v),
+                        Err(_) => ErrorKind::TestMoreError(None),
+                    },
+                    _ => ErrorKind::TestMoreError(None),
+                }
+            }
             _ => ErrorKind::VarlinkReply_Error,
         }
     }

--- a/examples/ping/src/org_example_ping.rs
+++ b/examples/ping/src/org_example_ping.rs
@@ -104,9 +104,7 @@ impl From<&varlink::Reply> for ErrorKind {
     #[allow(unused_variables)]
     fn from(e: &varlink::Reply) -> Self {
         match e {
-            varlink::Reply {
-                error: Some(ref t), ..
-            } if t == "org.example.ping.PingError" => match e {
+            varlink::Reply { error: Some(t), .. } if t == "org.example.ping.PingError" => match e {
                 varlink::Reply {
                     parameters: Some(p),
                     ..

--- a/varlink_generator/src/lib.rs
+++ b/varlink_generator/src/lib.rs
@@ -713,7 +713,7 @@ fn generate_error_code(
                 let error_name = format!("{iname}.{ename}", iname = idl.name, ename = t.name);
                 let ename = TokenStream::from_str(&format!("ErrorKind::{}", t.name)).unwrap();
                 arms.extend(quote!(
-                    varlink::Reply { error: Some(ref t), .. } if t == #error_name => {
+                    varlink::Reply { error: Some(t), .. } if t == #error_name => {
                         match e {
                            varlink::Reply {
                                parameters: Some(p),

--- a/varlink_generator/tests/org.example.complex.rs_out
+++ b/varlink_generator/tests/org.example.complex.rs_out
@@ -103,9 +103,7 @@ impl From<&varlink::Reply> for ErrorKind {
     #[allow(unused_variables)]
     fn from(e: &varlink::Reply) -> Self {
         match e {
-            varlink::Reply {
-                error: Some(ref t), ..
-            } if t == "org.example.complex.ErrorBar" => match e {
+            varlink::Reply { error: Some(t), .. } if t == "org.example.complex.ErrorBar" => match e {
                 varlink::Reply {
                     parameters: Some(p),
                     ..
@@ -115,9 +113,7 @@ impl From<&varlink::Reply> for ErrorKind {
                 },
                 _ => ErrorKind::ErrorBar(None),
             },
-            varlink::Reply {
-                error: Some(ref t), ..
-            } if t == "org.example.complex.ErrorFoo" => match e {
+            varlink::Reply { error: Some(t), ..  } if t == "org.example.complex.ErrorFoo" => match e {
                 varlink::Reply {
                     parameters: Some(p),
                     ..


### PR DESCRIPTION
This generates code which also compiles with Rust 2024.

See https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html

Fixes #121