### PR TITLE
chore: update `peg` to v0.8.5 and adjust interface parsing logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "peg"
-version = "0.6.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "peg-macros"
-version = "0.6.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "peg-runtime"
-version = "0.6.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ colored = "3.0.0"
 colored_json = "5.0.0"
 getopts = "0.2.21"
 libc = { version = "0.2.126", default-features = false }
-peg = "0.6.3"
+peg = "0.8.5"
 proc-macro2 = "1.0.6"
 quote = "1.0.2"
 serde = "1.0.102"

--- a/varlink_parser/src/lib.rs
+++ b/varlink_parser/src/lib.rs
@@ -232,7 +232,7 @@ impl<'a> TryFrom<&'a str> for IDL<'a> {
     type Error = Error;
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        let interface = ParseInterface(value).map_err(|e| {
+        let interface = ParseInterface(value, value).map_err(|e| {
             let line = value.split('\n').nth(e.location.line - 1).unwrap();
             Error::Parse {
                 line: line.to_string(),

--- a/varlink_parser/src/test.rs
+++ b/varlink_parser/src/test.rs
@@ -207,7 +207,8 @@ fn test_one_method() {
 
 #[test]
 fn test_one_method_no_type() {
-    assert!(ParseInterface("interface foo.bar\nmethod Foo()->(b:)").is_err());
+    let input = "interface foo.bar\nmethod Foo()->(b:)";
+    assert!(ParseInterface(input, input).is_err());
 }
 
 #[test]

--- a/varlink_parser/src/varlink_grammar.rs
+++ b/varlink_parser/src/varlink_grammar.rs
@@ -116,9 +116,9 @@ peg::parser! {
             / e:error() { MethodOrTypedefOrError::Error(e) }
 
         use crate::IDL;
-        pub rule ParseInterface() -> IDL<'input>
-            = d:$(wce()*) "interface" wce()+ n:$interface_name() eol() mt:(member()++ eol()) wce()*  {
-                IDL::from_token(__input, n, mt, trim_doc(d))
+        pub rule ParseInterface(full_input: &'input str) -> IDL<'input>
+            = d:$(wce()*) "interface" wce()+ n:$interface_name() eol() mt:(member()++ eol()) wce()* {
+                IDL::from_token(full_input, n, mt, trim_doc(d))
              }
 
     }


### PR DESCRIPTION
refactor `ParseInterface` function and test cases to include `full_input` parameter for improved parsing.