### PR TITLE
fix: add --all-features to coverage and lint workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run cargo-llvm-cov
         run: |
           mkdir coverage
-          cargo llvm-cov --workspace --lcov --output-path ./coverage/lcov.info
+          cargo llvm-cov --workspace --all-features --lcov --output-path ./coverage/lcov.info
 
       - name: Upload to coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-features -- -D warnings


### PR DESCRIPTION
The coverage and clippy workflows were not testing async code because they ran without --all-features. The tokio feature enables async support in the varlink crate, so without it:
- Code coverage excluded all async code paths
- Clippy did not lint async code

The CI workflow already had --all-features on line 47, so tests were running correctly, but coverage and linting were incomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)