### PR TITLE
feat: add MethodCall::push_fd() for passing file descriptors (SCM_RIGHTS)

### DIFF
--- a/varlink/src/lib.rs
+++ b/varlink/src/lib.rs
@@ -1137,16 +1137,37 @@ where
     /// SCM_RIGHTS ancillary data on the underlying socket. Returns the fd's index
     /// in push order — the value a method's parameters use to reference a passed fd.
     ///
+    /// File descriptor passing is not part of the core varlink protocol; it is an
+    /// extension introduced by systemd's `sd-varlink`, and this method mirrors
+    /// `sd_varlink_push_fd(3)`.
+    ///
     /// The fd is dup'd (F_DUPFD_CLOEXEC), so the caller keeps ownership of the
-    /// original. Only works on socket-backed connections (created via
-    /// [Connection::with_address]); a reader/writer-pair connection has no socket
-    /// to carry ancillary data and returns an error.
+    /// original. Only works on connections backed by an `AF_UNIX` socket (e.g.
+    /// created via [Connection::with_address] with a `unix:` address): SCM_RIGHTS
+    /// exists only there, so a TCP connection or a reader/writer-pair connection
+    /// (which has no socket at all) returns `ErrorKind::Unsupported`.
     #[cfg(unix)]
     pub fn push_fd(&mut self, fd: RawFd) -> std::io::Result<usize> {
-        if self.connection.read().unwrap().stream.is_none() {
+        let sock = match self.connection.read().unwrap().stream.as_ref() {
+            Some(s) => s.as_raw_fd(),
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "fd passing requires a socket-backed varlink connection",
+                ));
+            }
+        };
+        let mut addr: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+        let mut len = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+        if unsafe { libc::getsockname(sock, &mut addr as *mut _ as *mut libc::sockaddr, &mut len) }
+            < 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        if addr.ss_family != libc::AF_UNIX as libc::sa_family_t {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,
-                "fd passing requires a socket-backed varlink connection",
+                "fd passing (SCM_RIGHTS) requires an AF_UNIX socket",
             ));
         }
         let dup = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) };
@@ -1197,9 +1218,8 @@ where
             // SCM_RIGHTS on the underlying socket instead of the boxed writer.
             // Both share the same socket, so any tail past the single sendmsg is
             // written through the writer in order.
-            let mut sent = false;
             #[cfg(unix)]
-            if !self.fds.is_empty() {
+            let sent = if !self.fds.is_empty() {
                 let sock = conn
                     .stream
                     .as_ref()
@@ -1210,8 +1230,12 @@ where
                 if n < b.len() {
                     w.write_all(&b[n..]).map_err(map_context!())?;
                 }
-                sent = true;
-            }
+                true
+            } else {
+                false
+            };
+            #[cfg(not(unix))]
+            let sent = false;
             if !sent {
                 w.write_all(&b).map_err(map_context!())?;
             }

--- a/varlink/src/lib.rs
+++ b/varlink/src/lib.rs
@@ -247,6 +247,8 @@ use std::convert::From;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::process::Child;
 use std::sync::{Arc, RwLock};
 
@@ -1000,6 +1002,38 @@ impl Drop for Connection {
     }
 }
 
+/// Send `buf` on `sock` with `fds` attached as a single SCM_RIGHTS control
+/// message, returning the number of data bytes accepted (a short send is
+/// possible for large buffers; the caller writes any remainder normally).
+/// msghdr field widths differ across libcs (glibc/musl), hence the `as _` casts.
+#[cfg(unix)]
+fn sendmsg_with_fds(sock: RawFd, buf: &[u8], fds: &[OwnedFd]) -> std::io::Result<usize> {
+    let raw: Vec<RawFd> = fds.iter().map(|f| f.as_raw_fd()).collect();
+    let fd_bytes = std::mem::size_of_val(raw.as_slice());
+    let mut cmsg = vec![0u8; unsafe { libc::CMSG_SPACE(fd_bytes as u32) } as usize];
+    let iov = libc::iovec {
+        iov_base: buf.as_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &iov as *const _ as *mut _;
+    msg.msg_iovlen = 1 as _;
+    msg.msg_control = cmsg.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cmsg.len() as _;
+    unsafe {
+        let c = libc::CMSG_FIRSTHDR(&msg);
+        (*c).cmsg_level = libc::SOL_SOCKET;
+        (*c).cmsg_type = libc::SCM_RIGHTS;
+        (*c).cmsg_len = libc::CMSG_LEN(fd_bytes as u32) as _;
+        std::ptr::copy_nonoverlapping(raw.as_ptr() as *const u8, libc::CMSG_DATA(c), fd_bytes);
+    }
+    let n = unsafe { libc::sendmsg(sock, &msg, libc::MSG_NOSIGNAL) };
+    if n < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(n as usize)
+}
+
 pub struct MethodCall<MRequest, MReply, MError>
 where
     MRequest: Serialize,
@@ -1012,6 +1046,11 @@ where
     reader: Option<BufReader<Box<dyn Read + Send + Sync>>>,
     writer: Option<Box<dyn Write + Send + Sync>>,
     continues: bool,
+    /// File descriptors queued via [push_fd](#method.push_fd), attached to the
+    /// next send() as SCM_RIGHTS ancillary data. Kept as OwnedFd (dup'd copies)
+    /// so they stay valid until the message is on the wire, then dropped.
+    #[cfg(unix)]
+    fds: Vec<OwnedFd>,
     phantom_reply: PhantomData<MReply>,
     phantom_error: PhantomData<MError>,
 }
@@ -1050,9 +1089,35 @@ where
             continues: false,
             reader: None,
             writer: None,
+            #[cfg(unix)]
+            fds: Vec::new(),
             phantom_reply: PhantomData,
             phantom_error: PhantomData,
         }
+    }
+
+    /// Queue a file descriptor to be passed with the next send of this call, via
+    /// SCM_RIGHTS ancillary data on the underlying socket. Returns the fd's index
+    /// in push order — the value a method's parameters use to reference a passed fd.
+    ///
+    /// The fd is dup'd (F_DUPFD_CLOEXEC), so the caller keeps ownership of the
+    /// original. Only works on socket-backed connections (created via
+    /// [Connection::with_address]); a reader/writer-pair connection has no socket
+    /// to carry ancillary data and returns an error.
+    #[cfg(unix)]
+    pub fn push_fd(&mut self, fd: RawFd) -> std::io::Result<usize> {
+        if self.connection.read().unwrap().stream.is_none() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "fd passing requires a socket-backed varlink connection",
+            ));
+        }
+        let dup = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) };
+        if dup < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        self.fds.push(unsafe { OwnedFd::from_raw_fd(dup) });
+        Ok(self.fds.len() - 1)
     }
 
     fn send(&mut self, oneway: bool, more: bool, upgrade: bool) -> std::result::Result<(), MError> {
@@ -1091,7 +1156,28 @@ where
             // Use sans-io protocol serialization
             let b = crate::sansio::protocol::serialize_request(&req)?;
 
-            w.write_all(&b).map_err(map_context!())?;
+            // If fds were queued (push_fd), send the request via sendmsg with
+            // SCM_RIGHTS on the underlying socket instead of the boxed writer.
+            // Both share the same socket, so any tail past the single sendmsg is
+            // written through the writer in order.
+            let mut sent = false;
+            #[cfg(unix)]
+            if !self.fds.is_empty() {
+                let sock = conn
+                    .stream
+                    .as_ref()
+                    .map(|s| s.as_raw_fd())
+                    .ok_or_else(|| MError::from(context!(ErrorKind::ConnectionBusy)))?;
+                let n = sendmsg_with_fds(sock, &b, &self.fds).map_err(map_context!())?;
+                self.fds.clear();
+                if n < b.len() {
+                    w.write_all(&b[n..]).map_err(map_context!())?;
+                }
+                sent = true;
+            }
+            if !sent {
+                w.write_all(&b).map_err(map_context!())?;
+            }
             w.flush().map_err(map_context!())?;
             if oneway {
                 conn.writer = Some(w);

--- a/varlink/src/test.rs
+++ b/varlink/src/test.rs
@@ -209,3 +209,102 @@ fn test_handle() -> Result<()> {
     );
     Ok(())
 }
+
+// push_fd is only meaningful on a socket-backed connection: a reader/writer-pair
+// connection (Connection::default here) has no socket for ancillary data.
+#[cfg(unix)]
+#[test]
+fn test_push_fd_requires_socket() {
+    let conn = Arc::new(RwLock::new(Connection::default()));
+    let mut call = MethodCall::<serde_json::Value, serde_json::Value, Error>::new(
+        conn,
+        "org.example.Test.Method",
+        serde_json::json!({}),
+    );
+    let err = call.push_fd(0).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+}
+
+// push_fd attaches descriptors to the outgoing message via SCM_RIGHTS. Send over
+// one end of a socketpair and recvmsg() the other end to confirm the fd arrives,
+// referring to the same underlying object (a pipe we can then read through).
+#[cfg(unix)]
+#[test]
+fn test_push_fd_passes_descriptor() -> Result<()> {
+    use std::io::Read;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::os::unix::net::UnixStream;
+
+    let (client, server) = UnixStream::pair().unwrap();
+
+    // Pipe whose write end we pass; reading its read end proves the fd traveled.
+    let mut pipe = [0i32; 2];
+    assert_eq!(unsafe { libc::pipe(pipe.as_mut_ptr()) }, 0);
+    let (pipe_r, pipe_w) =
+        unsafe { (OwnedFd::from_raw_fd(pipe[0]), OwnedFd::from_raw_fd(pipe[1])) };
+
+    let reader = Box::new(client.try_clone().unwrap());
+    let writer = Box::new(client.try_clone().unwrap());
+    // Connection implements Drop, so the fields must be listed explicitly (no
+    // ..Default::default() functional update).
+    let conn = Arc::new(RwLock::new(Connection {
+        reader: Some(BufReader::new(reader)),
+        writer: Some(writer),
+        address: String::new(),
+        stream: Some(Box::new(client)),
+        child: None,
+        tempdir: None,
+    }));
+
+    let mut call = MethodCall::<serde_json::Value, serde_json::Value, Error>::new(
+        conn,
+        "org.example.Test.Method",
+        serde_json::json!({}),
+    );
+    assert_eq!(call.push_fd(pipe_w.as_raw_fd()).unwrap(), 0);
+    call.oneway()?; // sends the request with the fd attached
+    drop(pipe_w); // leave the received dup as the pipe's only writer
+
+    // recvmsg() the request bytes plus the SCM_RIGHTS descriptor.
+    let mut buf = [0u8; 256];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    let mut cbuf =
+        vec![0u8; unsafe { libc::CMSG_SPACE(std::mem::size_of::<i32>() as u32) } as usize];
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1 as _;
+    msg.msg_control = cbuf.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cbuf.len() as _;
+
+    let n = unsafe { libc::recvmsg(server.as_raw_fd(), &mut msg, 0) };
+    assert!(n > 0, "recvmsg returned {}", n);
+    // A varlink message is NUL-terminated JSON.
+    assert!(buf[..n as usize].contains(&0));
+
+    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+    assert!(!cmsg.is_null(), "no control message received");
+    assert_eq!(unsafe { (*cmsg).cmsg_level }, libc::SOL_SOCKET);
+    assert_eq!(unsafe { (*cmsg).cmsg_type }, libc::SCM_RIGHTS);
+    let received_fd = unsafe { std::ptr::read_unaligned(libc::CMSG_DATA(cmsg) as *const i32) };
+    let received = unsafe { OwnedFd::from_raw_fd(received_fd) };
+
+    // Writing through the received fd must surface on our pipe's read end.
+    let payload = b"hi";
+    let w = unsafe {
+        libc::write(
+            received.as_raw_fd(),
+            payload.as_ptr() as *const libc::c_void,
+            payload.len(),
+        )
+    };
+    assert_eq!(w, payload.len() as isize);
+    drop(received);
+
+    let mut got = [0u8; 2];
+    std::fs::File::from(pipe_r).read_exact(&mut got).unwrap();
+    assert_eq!(&got, payload);
+    Ok(())
+}

--- a/varlink/src/test.rs
+++ b/varlink/src/test.rs
@@ -225,6 +225,36 @@ fn test_push_fd_requires_socket() {
     assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
 }
 
+// SCM_RIGHTS is AF_UNIX-only, so a TCP-backed connection must be rejected at
+// push_fd() time rather than failing later in sendmsg().
+#[cfg(unix)]
+#[test]
+fn test_push_fd_requires_unix_socket() {
+    use std::net::{TcpListener, TcpStream};
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let stream = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+
+    let reader = Box::new(stream.try_clone().unwrap());
+    let writer = Box::new(stream.try_clone().unwrap());
+    let conn = Arc::new(RwLock::new(Connection {
+        reader: Some(BufReader::new(reader)),
+        writer: Some(writer),
+        address: String::new(),
+        stream: Some(Box::new(stream)),
+        child: None,
+        tempdir: None,
+    }));
+
+    let mut call = MethodCall::<serde_json::Value, serde_json::Value, Error>::new(
+        conn,
+        "org.example.Test.Method",
+        serde_json::json!({}),
+    );
+    let err = call.push_fd(0).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+}
+
 // push_fd attaches descriptors to the outgoing message via SCM_RIGHTS. Send over
 // one end of a socketpair and recvmsg() the other end to confirm the fd arrives,
 // referring to the same underlying object (a pipe we can then read through).
@@ -306,5 +336,113 @@ fn test_push_fd_passes_descriptor() -> Result<()> {
     let mut got = [0u8; 2];
     std::fs::File::from(pipe_r).read_exact(&mut got).unwrap();
     assert_eq!(&got, payload);
+    Ok(())
+}
+
+// Multiple push_fd calls return consecutive indices and deliver all fds in one
+// SCM_RIGHTS control message, each mapping back to the right object; after a
+// send the queue is cleared, so a second send carries no ancillary data.
+#[cfg(unix)]
+#[test]
+fn test_push_fd_multiple_and_cleared_after_send() -> Result<()> {
+    use std::io::Read;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::os::unix::net::UnixStream;
+
+    let (client, server) = UnixStream::pair().unwrap();
+
+    // Two pipes; we pass both write ends and tell the received fds apart by
+    // writing a distinct payload through each.
+    let mut p1 = [0i32; 2];
+    let mut p2 = [0i32; 2];
+    assert_eq!(unsafe { libc::pipe(p1.as_mut_ptr()) }, 0);
+    assert_eq!(unsafe { libc::pipe(p2.as_mut_ptr()) }, 0);
+    let (r1, w1) = unsafe { (OwnedFd::from_raw_fd(p1[0]), OwnedFd::from_raw_fd(p1[1])) };
+    let (r2, w2) = unsafe { (OwnedFd::from_raw_fd(p2[0]), OwnedFd::from_raw_fd(p2[1])) };
+
+    let reader = Box::new(client.try_clone().unwrap());
+    let writer = Box::new(client.try_clone().unwrap());
+    let conn = Arc::new(RwLock::new(Connection {
+        reader: Some(BufReader::new(reader)),
+        writer: Some(writer),
+        address: String::new(),
+        stream: Some(Box::new(client)),
+        child: None,
+        tempdir: None,
+    }));
+
+    let mut call = MethodCall::<serde_json::Value, serde_json::Value, Error>::new(
+        conn,
+        "org.example.Test.Method",
+        serde_json::json!({}),
+    );
+    assert_eq!(call.push_fd(w1.as_raw_fd()).unwrap(), 0);
+    assert_eq!(call.push_fd(w2.as_raw_fd()).unwrap(), 1);
+    call.oneway()?;
+    drop((w1, w2)); // leave the received dups as the pipes' only writers
+
+    let mut buf = [0u8; 256];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    let mut cbuf =
+        vec![0u8; unsafe { libc::CMSG_SPACE(2 * std::mem::size_of::<i32>() as u32) } as usize];
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1 as _;
+    msg.msg_control = cbuf.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cbuf.len() as _;
+
+    let n = unsafe { libc::recvmsg(server.as_raw_fd(), &mut msg, 0) };
+    assert!(n > 0, "recvmsg returned {}", n);
+
+    // Exactly one control message, sized for both fds.
+    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+    assert!(!cmsg.is_null(), "no control message received");
+    assert_eq!(unsafe { (*cmsg).cmsg_level }, libc::SOL_SOCKET);
+    assert_eq!(unsafe { (*cmsg).cmsg_type }, libc::SCM_RIGHTS);
+    assert_eq!(unsafe { (*cmsg).cmsg_len } as usize, unsafe {
+        libc::CMSG_LEN(2 * std::mem::size_of::<i32>() as u32)
+    } as usize);
+    assert!(unsafe { libc::CMSG_NXTHDR(&msg, cmsg) }.is_null());
+
+    let data = unsafe { libc::CMSG_DATA(cmsg) };
+    let fd0 = unsafe { std::ptr::read_unaligned(data as *const i32) };
+    let fd1 =
+        unsafe { std::ptr::read_unaligned(data.add(std::mem::size_of::<i32>()) as *const i32) };
+    let (recv0, recv1) = unsafe { (OwnedFd::from_raw_fd(fd0), OwnedFd::from_raw_fd(fd1)) };
+
+    // Push order is preserved: index 0 writes into pipe 1, index 1 into pipe 2.
+    for (fd, pipe_r, payload) in [(recv0, r1, b"p1"), (recv1, r2, b"p2")] {
+        let w = unsafe {
+            libc::write(
+                fd.as_raw_fd(),
+                payload.as_ptr() as *const libc::c_void,
+                payload.len(),
+            )
+        };
+        assert_eq!(w, payload.len() as isize);
+        drop(fd);
+        let mut got = [0u8; 2];
+        std::fs::File::from(pipe_r).read_exact(&mut got).unwrap();
+        assert_eq!(&got, payload);
+    }
+
+    // The queue was cleared on send: a second send on the same connection must
+    // arrive without any ancillary data.
+    let mut call = MethodCall::<serde_json::Value, serde_json::Value, Error>::new(
+        call.connection.clone(),
+        "org.example.Test.Method",
+        serde_json::json!({}),
+    );
+    call.oneway()?;
+    msg.msg_controllen = cbuf.len() as _;
+    let n = unsafe { libc::recvmsg(server.as_raw_fd(), &mut msg, 0) };
+    assert!(n > 0, "recvmsg returned {}", n);
+    assert_eq!(
+        msg.msg_controllen, 0,
+        "unexpected ancillary data on second send"
+    );
     Ok(())
 }


### PR DESCRIPTION
systemd's `sd-varlink` extends varlink with file-descriptor passing over the
Unix socket via SCM_RIGHTS: fds are pushed before the call and referenced from
the parameters by their push-order index. (This is not part of the core varlink
protocol as specified on varlink.org — the push-order convention is the de-facto
one used by systemd's services.) This crate had no client-side way to attach
fds; this adds that, mirroring `sd_varlink_push_fd()`.

## API

```rust
let mut call = client.some_method(args);
let idx = call.push_fd(fd)?;   // -> 0, then 1, ... (push order == the index methods reference)
call.more()?;                  // or .call()/.oneway(); fds are delivered with the request
```

- `MethodCall::push_fd(fd) -> io::Result<usize>` (unix only). Dups the fd with
  `F_DUPFD_CLOEXEC` (caller keeps ownership of the original), queues it, and
  returns its push-order index.
- On send, queued fds are delivered with the request via a single
  `sendmsg()` + `SCM_RIGHTS` on the connection's socket; any bytes past the first
  `sendmsg` are written normally through the existing writer.
- Only `AF_UNIX`-socket-backed connections support this — SCM_RIGHTS does not
  exist elsewhere. `push_fd` checks the socket family up front (`getsockname`),
  so a `tcp:` connection or a reader/writer-pair connection fails immediately
  with `io::ErrorKind::Unsupported` rather than later at send time.

No opt-in gate (cf. systemd's `SD_VARLINK_SERVER_ALLOW_FD_PASSING_OUTPUT`):
on the client side, calling `push_fd` is itself the explicit opt-in — no
ancillary data is ever attached unless the application pushed an fd for that
specific call.

## Scope

Send-only. Receiving descriptors (server → client) is not implemented — it would
require recvmsg-based reading throughout the input path, and nothing needs it yet.
`cfg(unix)` only, matching the crate's existing platform split; `libc` is already
a unix dependency.

## Tests

`varlink/src/test.rs`:
- `test_push_fd_passes_descriptor`: push an fd over one end of a socketpair,
  `recvmsg()` the other end, and confirm the descriptor arrives and refers to the
  same underlying pipe (write through the received fd, read it back).
- `test_push_fd_multiple_and_cleared_after_send`: two fds arrive in one
  SCM_RIGHTS control message with consecutive indices and push order preserved;
  the queue is cleared on send, so a second send carries no ancillary data.
- `test_push_fd_requires_socket`: `push_fd` on a non-socket connection returns
  `Unsupported`.
- `test_push_fd_requires_unix_socket`: `push_fd` on a TCP-backed connection
  returns `Unsupported`.

`cargo test -p varlink` passes.
